### PR TITLE
Increase Max Sample/S & FFT Len, Minor UI Changes

### DIFF
--- a/audioSpectrumAnalyzer/src/main/java/github/bewantbe/audio_analyzer_for_android/SelectorText.java
+++ b/audioSpectrumAnalyzer/src/main/java/github/bewantbe/audio_analyzer_for_android/SelectorText.java
@@ -39,7 +39,7 @@ import android.widget.TextView;
 public class SelectorText extends TextView {
   static final String TAG = "SelectorText:";
   private static float DPRatio;
-  private static final int ANIMATION_DELAY = 100;
+  private static final int ANIMATION_DELAY = 70;
   private int value_id = 0;
   private String[] values = new String[0];
   private String[] valuesDisplay = new String[0];

--- a/audioSpectrumAnalyzer/src/main/res/layout-land/main.xml
+++ b/audioSpectrumAnalyzer/src/main/res/layout-land/main.xml
@@ -142,7 +142,7 @@
             android:tag="select"
             android:text="linear"
             android:textSize="20sp"
-            custom:items="linear log" />
+            custom:items="linear log note"/>
 
         <github.bewantbe.audio_analyzer_for_android.SelectorText
             android:id="@+id/run"

--- a/audioSpectrumAnalyzer/src/main/res/layout-port/main.xml
+++ b/audioSpectrumAnalyzer/src/main/res/layout-port/main.xml
@@ -116,7 +116,7 @@
             android:paddingLeft="15dp"
             android:paddingStart="15dp"
             android:tag="select"
-            android:text="spum"
+            android:text="1D"
             android:textSize="20sp"
             custom:itemsDisplay="@string/button_spectrum_spectrogram_mode"
             custom:items="spum spam" />

--- a/audioSpectrumAnalyzer/src/main/res/values/arrays.xml
+++ b/audioSpectrumAnalyzer/src/main/res/values/arrays.xml
@@ -96,6 +96,7 @@
         <item>44100::44100</item>
         <item>48000::48000</item>
         <item>96000::96000</item>
+        <item>192000::192000</item>
     </string-array>
     <string-array name="fft_len" translatable="false">
         <item>@string/fft_len_name</item>
@@ -104,6 +105,7 @@
         <item>2048::2048</item>
         <item>4096::4096</item>
         <item>8192::8192</item>
+        <item>16384::16384</item>
     </string-array>
     <string-array name="fft_ave_num" translatable="false">
         <item>@string/fft_ave_num_name</item>

--- a/audioSpectrumAnalyzer/src/main/res/values/strings.xml
+++ b/audioSpectrumAnalyzer/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="button_freq_scaling_mode">linear::log::note</string>
     <string name="button_run">run::stop</string>
     <string name="button_dbA">dB::dBA</string>
-    <string name="button_spectrum_spectrogram_mode">spum::spam</string>
+    <string name="button_spectrum_spectrogram_mode">1D::2D</string>
     <string name="button_recording">Mon::Rec</string>
 
     <!-- permission dialog -->


### PR DESCRIPTION
Added support for 192kHz devices, doubled maximum FFT length choice, and
fixed support for landscape view musical note (pitch) view.

Known Issue: At maximum FFT length and Sample Rate settings, linear view
experiences a bug and does not display correctly.

Workaround: Please choose either logarithmic or note view at this high
(maximum) performance level.

Other changes:

**Simplify Portrait Graph Context to 1D/2D**

Provides users in portrait mode a simplified context for which to choose
between the spectrogram (2D) graph view and the spectrum (1D) graph
view. Landscape has more screen "real estate" to display the "spam" and
"spum" titles, which will show while switching between display
orientations.

**Add in support for landscape note view.**

Now it is possible to choose to access the Pitch view in landscape.

**Make animation delay more responsive feeling.**

Very minor change but helps the app feel slightly more responsive.

Note: The "refresh" branch is a pulled directly from the latest version of bewantbe/master and has only the real changes from PR #9, but in a much cleaner style.